### PR TITLE
When resetting with no selection, apply reset to current line.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -11,6 +11,8 @@ import { SetAction } from "./src/setChecklistItems";
 import { ChecklistResetSettings } from "src/types";
 import { handleCanvasAction } from "src/handleCanvasAction";
 import { handleMarkdownAction } from "src/handleMarkdownAction";
+import { getMarkdownSelectionToReset } from "src/getMarkdownSelectionToReset";
+import { restoreCursorAfterReset } from "src/restoreCursorAfterReset";
 
 const DEFAULT_SETTINGS: ChecklistResetSettings = { deleteTextOnReset: "" };
 
@@ -108,12 +110,17 @@ export default class ChecklistReset extends Plugin {
         } else if (view instanceof MarkdownView) {
           const selectedText = view.editor.listSelections();
           if (selectedText.length > 0) {
+            const selection = selectedText[0];
+            const lineLength = view.editor.getLine(selection.head.line).length;
+
             handleMarkdownAction(
               view,
               this.settings,
               "uncheck",
-              selectedText[0]
+              getMarkdownSelectionToReset(selection, lineLength)
             );
+
+            restoreCursorAfterReset(view.editor, selection, selectedText.length);
           }
         }
       },

--- a/src/getMarkdownSelectionToReset.test.ts
+++ b/src/getMarkdownSelectionToReset.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { getMarkdownSelectionToReset } from "./getMarkdownSelectionToReset";
+
+describe("getMarkdownSelectionToReset", () => {
+  it("returns the original selection when text is selected", () => {
+    const selection = {
+      anchor: { line: 1, ch: 2 },
+      head: { line: 1, ch: 8 },
+    };
+
+    expect(getMarkdownSelectionToReset(selection, 10)).toEqual(selection);
+  });
+
+  it("falls back to the full selected line when the selection is collapsed", () => {
+    expect(
+      getMarkdownSelectionToReset(
+        {
+          anchor: { line: 1, ch: 4 },
+          head: { line: 1, ch: 4 },
+        },
+        10
+      )
+    ).toEqual({
+      anchor: { line: 1, ch: 0 },
+      head: { line: 1, ch: 10 },
+    });
+  });
+});

--- a/src/getMarkdownSelectionToReset.ts
+++ b/src/getMarkdownSelectionToReset.ts
@@ -1,0 +1,20 @@
+import type { EditorSelection } from "obsidian";
+
+export function getMarkdownSelectionToReset(
+  selection: EditorSelection,
+  lineLength: number
+): EditorSelection {
+  const hasSelection =
+    selection.anchor.line !== selection.head.line ||
+    selection.anchor.ch !== selection.head.ch;
+
+  if (hasSelection) {
+    return selection;
+  }
+
+  const line = selection.head.line;
+  return {
+    anchor: { line, ch: 0 },
+    head: { line, ch: lineLength },
+  };
+}

--- a/src/restoreCursorAfterReset.test.ts
+++ b/src/restoreCursorAfterReset.test.ts
@@ -42,6 +42,24 @@ describe("restoreCursorAfterReset", () => {
     expect(setCursor).not.toHaveBeenCalled();
   });
 
+  it("does not restore cursor when the selection is not collapsed", () => {
+    const setCursor = vi.fn();
+
+    restoreCursorAfterReset(
+      {
+        getLine: () => "- [ ] do thing",
+        setCursor,
+      },
+      {
+        anchor: { line: 0, ch: 5 },
+        head: { line: 0, ch: 8 },
+      },
+      1
+    );
+
+    expect(setCursor).not.toHaveBeenCalled();
+  });
+
   it("restores the same collapsed cursor column when updated line is longer", () => {
     const setCursor = vi.fn();
 

--- a/src/restoreCursorAfterReset.test.ts
+++ b/src/restoreCursorAfterReset.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { restoreCursorAfterReset } from "./restoreCursorAfterReset";
+
+describe("restoreCursorAfterReset", () => {
+  it("clamps the restored column to the updated line length", () => {
+    const setCursor = vi.fn();
+
+    restoreCursorAfterReset(
+      {
+        getLine: () => "- [ ] do thing",
+        setCursor,
+      },
+      {
+        anchor: { line: 0, ch: 20 },
+        head: { line: 0, ch: 20 },
+      },
+      1
+    );
+
+    expect(setCursor).toHaveBeenCalledWith({
+      line: 0,
+      ch: "- [ ] do thing".length,
+    });
+  });
+
+  it("does not restore cursor when there are multiple selections", () => {
+    const setCursor = vi.fn();
+
+    restoreCursorAfterReset(
+      {
+        getLine: () => "- [ ] do thing",
+        setCursor,
+      },
+      {
+        anchor: { line: 0, ch: 5 },
+        head: { line: 0, ch: 5 },
+      },
+      2
+    );
+
+    expect(setCursor).not.toHaveBeenCalled();
+  });
+
+  it("restores the same collapsed cursor column when updated line is longer", () => {
+    const setCursor = vi.fn();
+
+    restoreCursorAfterReset(
+      {
+        getLine: () => "- [ ] do thing and then keep writing",
+        setCursor,
+      },
+      {
+        anchor: { line: 0, ch: 6 },
+        head: { line: 0, ch: 6 },
+      },
+      1
+    );
+
+    expect(setCursor).toHaveBeenCalledWith({
+      line: 0,
+      ch: 6,
+    });
+  });
+});

--- a/src/restoreCursorAfterReset.ts
+++ b/src/restoreCursorAfterReset.ts
@@ -1,0 +1,26 @@
+import type { EditorPosition, EditorSelection } from "obsidian";
+
+type EditorLike = {
+  getLine: (line: number) => string;
+  setCursor: (position: EditorPosition) => void;
+};
+
+export function restoreCursorAfterReset(
+  editor: EditorLike,
+  selection: EditorSelection,
+  selectionCount: number
+) {
+  const isCollapsed =
+    selection.anchor.line === selection.head.line &&
+    selection.anchor.ch === selection.head.ch;
+
+  if (!isCollapsed || selectionCount !== 1) {
+    return;
+  }
+
+  const updatedLineLength = editor.getLine(selection.head.line).length;
+  editor.setCursor({
+    line: selection.head.line,
+    ch: Math.min(selection.head.ch, updatedLineLength),
+  });
+}


### PR DESCRIPTION
Resolves https://github.com/lhansford/obsidian-checklist-reset/issues/23

## Pull request overview

This PR adds a small, testable helper to normalize Markdown editor selections for the "Reset selected checklists" command, and adds unit tests to ensure collapsed selections are treated as "current line" (instead of doing nothing).

**Changes:**

• Extract getMarkdownSelectionToReset helper to normalize selection vs. cursor state.
• Added restoreCursorAfterReset helper to encapsulate cursor restoration rules and line-length clamping.
• Add unit tests covering non-empty selections and collapsed-selection fallback-to-line behavior and for cursor clamping after content shrink and for skipping restoration when multiple selections are active
• Wire main.ts to use the new helpers when invoking handleMarkdownAction for Markdown views.
